### PR TITLE
Split configs

### DIFF
--- a/asset-configs/broken.json
+++ b/asset-configs/broken.json
@@ -1,0 +1,395 @@
+
+// export const configFileSample= {
+//     "version": "0.9.2",
+//     "modules": {
+//     },
+//     "systems": {
+//     }
+// }
+
+
+export const configFileSample= {
+    "version": "0.9.2",
+    "modules": {
+        "acb5abe5-6de1-4856-b1db-9b3cb2cf3a9c": {
+            "name": {
+                "value": "modules.light.name"
+            },
+            "meta": {
+                "id": "Lights"
+            },
+            "type": "light",
+            "systemIds": [
+                "bd0a104d-be72-4c51-a071-4e2d3628048b",
+                "139590ce-2971-4e26-880b-2ff4b1ba29dc",
+                "025c66d3-35c0-47a1-aaba-3e41e4456b14"
+            ],
+            "config": {
+                "presets": {
+                    "1": "#ffffff",
+                    "2": "#ff0000",
+                    "3": "#0034ff"
+                }
+            }
+        },
+        "9f75f709-c65e-4006-a8df-7d2aaaf7fb3a": {
+            "name": {
+                "value": "display.name_1",
+                "params": {
+                    "name": { "value": "modules.slideout.name" },
+                    "location1": { "value": "location.front" }
+                }
+            },
+            "meta": {
+                "id": "Slideouts - Front"
+            },
+            "type": "slideout",
+            "systemIds": [
+                "2bce0e30-ca02-4437-93a5-7598c1ed3ac7",
+                "ea088168-96a5-4b97-b241-7cb66f919536"
+            ],
+            "config": {
+                "simultaneousControl": true
+            }
+        },
+        "b4ab4584-667b-486d-bc1b-7737941f9672": {
+            "name": {
+                "value": "display.name_1",
+                "params": {
+                    "name": { "value": "modules.interlock.name" },
+                    "location1": { "value": "location.streetside" }
+                }
+            },
+            "meta": {
+                "id": "Interlocks - Streetside"
+            },
+            "type": "interlock",
+            "systemIds": [
+                "a215068e-d2fe-4bc5-90e9-1003a0b2d27a"
+            ],
+            "config": {
+                "svg": "RedstoneSSInterlockMap"
+            }
+        },
+        "9e1115e0-2aad-4182-9a6c-22c2ae97d683": {
+            "name": {
+                "value": "modules.mast.name"
+            },
+            "meta": {
+                "id": "masts"
+            },
+            "type": "mast",
+            "systemIds": [
+                "079a9599-0f66-4d48-b3ec-3366da22e97a",
+                "63f498ae-5c74-4307-b0ac-109b82319604"
+            ],
+            "config": {
+                "simultaneousControl": false
+            }
+        },
+        "3685bda7-78dd-44cb-8593-e78809651089": {
+            "name": {
+                "value": "display.name_1",
+                "params": {
+                    "name": { "value": "modules.hvac.name" },
+                    "location1": { "value": "location.rear" }
+                }
+            },
+            "meta": {
+                "id": "HVAC - Rear"
+            },
+            "type": "hvac",
+            "systemIds": [
+                "069dfb9a-216d-46ea-abb2-6878eb381642"
+            ],
+            "config": {
+            }
+        },
+    },
+    "systems": {
+        "bd0a104d-be72-4c51-a071-4e2d3628048b": {
+            "name": {
+                "value": "display.name_1",
+                "params": {
+                    "name": {
+                        "value": "modules.light.name_other"
+                    },
+                    "location1": { "value": "location.center" }
+                }
+            },
+            "meta": {
+                "id": "Center Lights"
+            },
+            "type": "light",
+            "config": {
+                "location": {
+                    "value": "common.room",
+                    "params": {  "room": {   "value": "3" } }
+                },
+                "color": true,
+                "brightness": true
+            },
+            "hardware": {
+                "actions": {
+                    "on": 1,
+                    "off": 0,
+                    "up": 0.1,
+                    "down": -0.1
+                },
+                "inputs": [
+                    {
+                        "unit": 1,
+                        "block": 9,
+                        "bit": 1,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "on"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 9,
+                        "bit": 0,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "off"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 8,
+                        "bit": 7,
+                        "event": {
+                            "type": "action",
+                            "key": "brightness",
+                            "value": "up"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 8,
+                        "bit": 6,
+                        "event": {
+                            "type": "action",
+                            "key": "brightness",
+                            "value": "down"
+                        }
+                    }
+                ],
+                "universePosition": 41
+            },
+            "triggers": [
+            ],
+            "preconditions": [
+            ]
+        },
+        "139590ce-2971-4e26-880b-2ff4b1ba29dc": {
+            "name": {
+                "value": "display.descriptiveName_2",
+                "params": {
+                    "description1": { "value": "modules.light.variants.beacon" },
+                    "name": {
+                        "value": "modules.light.name_other"
+                    },
+                    "location1": { "value": "modules.mast.name" },
+                    "location2": { "value": "location.front" }
+                }
+            },
+            "meta": {
+                "id": "Front Mast Beacon Lights"
+            },
+            "type": "light",
+            "config": {
+                "location": {
+                    "value": "misc.exterior"
+                },
+                "color": false,
+                "brightness": false
+            },
+            "hardware": {
+                "actions": {
+                    "on": 1,
+                    "off": 0
+                },
+                "inputs": [
+                    {
+                        "unit": 1,
+                        "block": 13,
+                        "bit": 1,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "on"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 12,
+                        "bit": 6,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "off"
+                        }
+                    }
+                ],
+                "outputs": [
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 5,
+                        "event": {
+                            "type": "sensor",
+                            "key": "status",
+                            "values": {
+                                "0": "off",
+                                "1": "on"
+                            }
+                        }
+                    }
+                ]
+            },
+            "triggers": [
+            ],
+            "preconditions": [
+            ]
+        },
+        "025c66d3-35c0-47a1-aaba-3e41e4456b14": {
+            "name": {
+                "value": "display.descriptiveName_3",
+                "params": {
+                    "description1": { "value": "modules.light.variants.task" },
+                    "name": {
+                        "value": "modules.light.name_other"
+                    },
+                    "location1": { "value" : "modules.slideout.name"},
+                    "location2": { "value": "location.rear" },
+                    "location3": { "value": "location.cs" }
+                }
+            },
+            "meta": {
+                "id": "CS Slideout Rear Task Lights"
+            },
+            "type": "light",
+            "config": {
+                "location": {
+                    "value": "common.room",
+                    "params": {  "room": {   "value": "3" } }
+                },
+                "color": true,
+                "brightness": true
+            },
+            "hardware": {
+                "actions": {
+                    "on": 1,
+                    "off": 0,
+                    "up": 0.1,
+                    "down": -0.1
+                },
+                "inputs": [
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 7,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "on"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 6,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "off"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 5,
+                        "event": {
+                            "type": "action",
+                            "key": "brightness",
+                            "value": "up"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 4,
+                        "event": {
+                            "type": "action",
+                            "key": "brightness",
+                            "value": "down"
+                        }
+                    }
+                ],
+                "universePosition": 66
+            },
+            "triggers": [
+            ],
+            "preconditions": [
+            ]
+        },
+        "a215068e-d2fe-4bc5-90e9-1003a0b2d27a": {
+            "name": {
+                "value": "display.location_3",
+                "params": {
+                    "location1": { "value": "misc.fiber" },
+                    "location2": { "value": "misc.passthrough" },
+                    "location3": { "value": "misc.door" }
+                }
+            },
+            "meta": {
+                "id": "SS Fiber Passthrough Door Interlock"
+            },
+            "type": "interlock",
+            "config": {
+                "location": {
+                    "value": "common.room",
+                    "params": {  "room": {   "value": "1" } }
+                },
+                "x": 150.0,
+                "y": 160.0,
+                "width": 20.0,
+                "height": 20.0,
+                "rotation": 0.0
+            },
+            "hardware": {
+                "inputs": [
+                    {
+                        "unit": 2,
+                        "block": 2,
+                        "bit": 3,
+                        "event": {
+                            "type": "sensor",
+                            "key": "status",
+                            "values": {
+                                "0": "unmet",
+                                "1": "met"
+                            }
+                        }
+                    }
+                ],
+                "group": "door",
+                "safety": "met",
+                "name": {
+                    "value": "SS Fiber Passthrough Door Interlock"
+                },
+                "meta": {
+                    "id": "SS Fiber Passthrough Door Interlock"
+                }
+            },
+            "triggers": [
+            ],
+            "preconditions": [
+            ]
+        },
+    }
+}

--- a/asset-configs/devcom.json
+++ b/asset-configs/devcom.json
@@ -1,0 +1,386 @@
+{
+    "version": "0.9.2",
+    "modules": {
+        "acb5abe5-6de1-4856-b1db-9b3cb2cf3a9c": {
+            "name": {
+                "value": "modules.light.name"
+            },
+            "meta": {
+                "id": "Lights"
+            },
+            "type": "light",
+            "systemIds": [
+                "bd0a104d-be72-4c51-a071-4e2d3628048b",
+                "139590ce-2971-4e26-880b-2ff4b1ba29dc",
+                "025c66d3-35c0-47a1-aaba-3e41e4456b14"
+            ],
+            "config": {
+                "presets": {
+                    "1": "#ffffff",
+                    "2": "#ff0000",
+                    "3": "#0034ff"
+                }
+            }
+        },
+        "9f75f709-c65e-4006-a8df-7d2aaaf7fb3a": {
+            "name": {
+                "value": "display.name_1",
+                "params": {
+                    "name": { "value": "modules.slideout.name" },
+                    "location1": { "value": "location.front" }
+                }
+            },
+            "meta": {
+                "id": "Slideouts - Front"
+            },
+            "type": "slideout",
+            "systemIds": [
+                "2bce0e30-ca02-4437-93a5-7598c1ed3ac7",
+                "ea088168-96a5-4b97-b241-7cb66f919536"
+            ],
+            "config": {
+                "simultaneousControl": true
+            }
+        },
+        "b4ab4584-667b-486d-bc1b-7737941f9672": {
+            "name": {
+                "value": "display.name_1",
+                "params": {
+                    "name": { "value": "modules.interlock.name" },
+                    "location1": { "value": "location.streetside" }
+                }
+            },
+            "meta": {
+                "id": "Interlocks - Streetside"
+            },
+            "type": "interlock",
+            "systemIds": [
+                "a215068e-d2fe-4bc5-90e9-1003a0b2d27a"
+            ],
+            "config": {
+                "svg": "RedstoneSSInterlockMap"
+            }
+        },
+        "9e1115e0-2aad-4182-9a6c-22c2ae97d683": {
+            "name": {
+                "value": "modules.mast.name"
+            },
+            "meta": {
+                "id": "masts"
+            },
+            "type": "mast",
+            "systemIds": [
+                "079a9599-0f66-4d48-b3ec-3366da22e97a",
+                "63f498ae-5c74-4307-b0ac-109b82319604"
+            ],
+            "config": {
+                "simultaneousControl": false
+            }
+        },
+        "3685bda7-78dd-44cb-8593-e78809651089": {
+            "name": {
+                "value": "display.name_1",
+                "params": {
+                    "name": { "value": "modules.hvac.name" },
+                    "location1": { "value": "location.rear" }
+                }
+            },
+            "meta": {
+                "id": "HVAC - Rear"
+            },
+            "type": "hvac",
+            "systemIds": [
+                "069dfb9a-216d-46ea-abb2-6878eb381642"
+            ],
+            "config": {
+            }
+        }
+    },
+    "systems": {
+        "bd0a104d-be72-4c51-a071-4e2d3628048b": {
+            "name": {
+                "value": "display.name_1",
+                "params": {
+                    "name": {
+                        "value": "modules.light.name_other"
+                    },
+                    "location1": { "value": "location.center" }
+                }
+            },
+            "meta": {
+                "id": "Center Lights"
+            },
+            "type": "light",
+            "config": {
+                "location": {
+                    "value": "common.room",
+                    "params": {  "room": {   "value": "3" } }
+                },
+                "color": true,
+                "brightness": true
+            },
+            "hardware": {
+                "actions": {
+                    "on": 1,
+                    "off": 0,
+                    "up": 0.1,
+                    "down": -0.1
+                },
+                "inputs": [
+                    {
+                        "unit": 1,
+                        "block": 9,
+                        "bit": 1,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "on"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 9,
+                        "bit": 0,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "off"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 8,
+                        "bit": 7,
+                        "event": {
+                            "type": "action",
+                            "key": "brightness",
+                            "value": "up"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 8,
+                        "bit": 6,
+                        "event": {
+                            "type": "action",
+                            "key": "brightness",
+                            "value": "down"
+                        }
+                    }
+                ],
+                "universePosition": 41
+            },
+            "triggers": [
+            ],
+            "preconditions": [
+            ]
+        },
+        "139590ce-2971-4e26-880b-2ff4b1ba29dc": {
+            "name": {
+                "value": "display.descriptiveName_2",
+                "params": {
+                    "description1": { "value": "modules.light.variants.beacon" },
+                    "name": {
+                        "value": "modules.light.name_other"
+                    },
+                    "location1": { "value": "modules.mast.name" },
+                    "location2": { "value": "location.front" }
+                }
+            },
+            "meta": {
+                "id": "Front Mast Beacon Lights"
+            },
+            "type": "light",
+            "config": {
+                "location": {
+                    "value": "misc.exterior"
+                },
+                "color": false,
+                "brightness": false
+            },
+            "hardware": {
+                "actions": {
+                    "on": 1,
+                    "off": 0
+                },
+                "inputs": [
+                    {
+                        "unit": 1,
+                        "block": 13,
+                        "bit": 1,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "on"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 12,
+                        "bit": 6,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "off"
+                        }
+                    }
+                ],
+                "outputs": [
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 5,
+                        "event": {
+                            "type": "sensor",
+                            "key": "status",
+                            "values": {
+                                "0": "off",
+                                "1": "on"
+                            }
+                        }
+                    }
+                ]
+            },
+            "triggers": [
+            ],
+            "preconditions": [
+            ]
+        },
+        "025c66d3-35c0-47a1-aaba-3e41e4456b14": {
+            "name": {
+                "value": "display.descriptiveName_3",
+                "params": {
+                    "description1": { "value": "modules.light.variants.task" },
+                    "name": {
+                        "value": "modules.light.name_other"
+                    },
+                    "location1": { "value" : "modules.slideout.name"},
+                    "location2": { "value": "location.rear" },
+                    "location3": { "value": "location.cs" }
+                }
+            },
+            "meta": {
+                "id": "CS Slideout Rear Task Lights"
+            },
+            "type": "light",
+            "config": {
+                "location": {
+                    "value": "common.room",
+                    "params": {  "room": {   "value": "3" } }
+                },
+                "color": true,
+                "brightness": true
+            },
+            "hardware": {
+                "actions": {
+                    "on": 1,
+                    "off": 0,
+                    "up": 0.1,
+                    "down": -0.1
+                },
+                "inputs": [
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 7,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "on"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 6,
+                        "event": {
+                            "type": "action",
+                            "key": "power",
+                            "value": "off"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 5,
+                        "event": {
+                            "type": "action",
+                            "key": "brightness",
+                            "value": "up"
+                        }
+                    },
+                    {
+                        "unit": 1,
+                        "block": 6,
+                        "bit": 4,
+                        "event": {
+                            "type": "action",
+                            "key": "brightness",
+                            "value": "down"
+                        }
+                    }
+                ],
+                "universePosition": 66
+            },
+            "triggers": [
+            ],
+            "preconditions": [
+            ]
+        },
+        "a215068e-d2fe-4bc5-90e9-1003a0b2d27a": {
+            "name": {
+                "value": "display.location_3",
+                "params": {
+                    "location1": { "value": "misc.fiber" },
+                    "location2": { "value": "misc.passthrough" },
+                    "location3": { "value": "misc.door" }
+                }
+            },
+            "meta": {
+                "id": "SS Fiber Passthrough Door Interlock"
+            },
+            "type": "interlock",
+            "config": {
+                "location": {
+                    "value": "common.room",
+                    "params": {  "room": {   "value": "1" } }
+                },
+                "x": 150.0,
+                "y": 160.0,
+                "width": 20.0,
+                "height": 20.0,
+                "rotation": 0.0
+            },
+            "hardware": {
+                "inputs": [
+                    {
+                        "unit": 2,
+                        "block": 2,
+                        "bit": 3,
+                        "event": {
+                            "type": "sensor",
+                            "key": "status",
+                            "values": {
+                                "0": "unmet",
+                                "1": "met"
+                            }
+                        }
+                    }
+                ],
+                "group": "door",
+                "safety": "met",
+                "name": {
+                    "value": "SS Fiber Passthrough Door Interlock"
+                },
+                "meta": {
+                    "id": "SS Fiber Passthrough Door Interlock"
+                }
+            },
+            "triggers": [
+            ],
+            "preconditions": [
+            ]
+        }
+    }
+
+}

--- a/asset-configs/tmobile.json
+++ b/asset-configs/tmobile.json
@@ -1,0 +1,4 @@
+{
+	"type": "asset-config",
+	"contents": "so much stuff"
+}

--- a/configurations/modules/awning_module.json
+++ b/configurations/modules/awning_module.json
@@ -1,0 +1,33 @@
+{
+	"type": "awning",	
+	"fields": {
+            "displayName": {
+                "label": "Display Name",
+                "path": "meta.id",
+                "additionalPaths": ["id"],
+                "type": "input",
+                "value": "Awning"
+            },
+            "name": {
+                "label": "Name",
+                "path": "name",
+                "type": "translation",
+                "value": { "value": "modules.awning.name" }
+            },
+            "type": {
+                "label": "Type",
+                "path": "type",
+                "type": "dropdown",
+                "values": "moduleTypes",
+                "readonly": true,
+                "value": "Awning"
+            },
+            "systemIds": {
+                "label": "Systems",
+                "path": "systemIds",
+                "type": "multiselect",
+                "values": "existingSystemsForModule",
+                "value": []
+            }
+        }
+}

--- a/configurations/modules/batterymonitor_module.json
+++ b/configurations/modules/batterymonitor_module.json
@@ -1,0 +1,34 @@
+{
+	"type": "batteryMonitor",
+	"fields": {
+            "displayName": {
+                "label": "Display Name",
+                "path": "meta.id",
+                "additionalPaths": ["id"],
+                "type": "input",
+                "value": "Battery Monitor"
+            },
+            "name": {
+                "label": "Name",
+                "path": "name",
+                "type": "translation",
+                "value": { "value": "modules.batteryMonitor.name" }
+            },
+            "type": {
+                "label": "Type",
+                "path": "type",
+                "type": "dropdown",
+                "values": "moduleTypes",
+                "readonly": true,
+                "value": "Battery Monitor"
+            },
+            "systemIds": {
+                "label": "Systems",
+                "path": "systemIds",
+                "type": "multiselect",
+                "values": "existingSystemsForModule",
+                "value": []
+            }
+        }
+
+}

--- a/configurations/modules/generator_module.json
+++ b/configurations/modules/generator_module.json
@@ -1,0 +1,33 @@
+{
+	"type": "generator",
+	"fields": {
+            "displayName": {
+                "label": "Display Name",
+                "path": "meta.id",
+                "additionalPaths": ["id"],
+                "type": "input",
+                "value": "Generator"
+            },
+            "name": {
+                "label": "Name",
+                "path": "name",
+                "type": "translation",
+                "value": { "value": "modules.generator.name" }
+            },
+            "type": {
+                "label": "Type",
+                "path": "type",
+                "type": "dropdown",
+                "values": "moduleTypes",
+                "readonly": true,
+                "value": "Generator"
+            },
+            "systemIds": {
+                "label": "Systems",
+                "path": "systemIds",
+                "type": "multiselect",
+                "values": "existingSystemsForModule",
+                "value": []
+            }
+        }
+}

--- a/configurations/modules/interlock_module.json
+++ b/configurations/modules/interlock_module.json
@@ -1,5 +1,5 @@
 {
-    "type": "hvac",
+    "type": "interlock",
     "fields": {
         "displayName": {
             "label": "Display Name",
@@ -29,6 +29,13 @@
             "type": "multiselect",
             "values": "existingSystemsForModule",
             "value": []
+        },
+        "interlock-map": {
+            "label": "Interlock Map",
+            "path": "config.svg",
+            "type": "interlock-map",
+            "format": "string",
+            "value": ""
         }
     }
 }

--- a/configurations/modules/leveling_module.json
+++ b/configurations/modules/leveling_module.json
@@ -1,5 +1,5 @@
 {
-    "type": "hvac",
+    "type": "leveling",
     "fields": {
         "displayName": {
             "label": "Display Name",
@@ -13,7 +13,7 @@
             "label": "Name",
             "path": "name",
             "type": "translation",
-            "value": { "value": "modules.hvac.name" }
+            "value": { "value": "modules.leveling.name" }
         },
         "type": {
             "label": "Type",
@@ -21,7 +21,7 @@
             "type": "dropdown",
             "values": "moduleTypes",
             "readonly": true,
-            "value": "hvac"
+            "value": "leveling"
         },
         "systemIds": {
             "label": "Systems",
@@ -29,6 +29,6 @@
             "type": "multiselect",
             "values": "existingSystemsForModule",
             "value": []
-        }
+        }        
     }
 }

--- a/configurations/modules/light_module.json
+++ b/configurations/modules/light_module.json
@@ -1,0 +1,61 @@
+{
+    "type": "light",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Lights"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.light.name" }
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "format": "string",
+            "values": "moduleTypes",
+            "required": true,
+            "readonly": true,
+            "value": "light"
+        },
+        "systemIds": {
+            "label": "Systems",
+            "path": "systemIds",
+            "type": "multiselect",
+            "values": "existingSystemsForModule",
+            "format": "array",
+            "value": [
+            ]
+        },
+        "color-1": {
+            "label": "Color 1",
+            "path": "config.presets.1",
+            "type": "input",
+            "format": "hexColorCode",
+            "required": true,
+            "value": "#ffffff"
+        },
+        "color-2": {
+            "label": "Color 2",
+            "path": "config.presets.2",
+            "type": "input",
+            "format": "hexColorCode",
+            "required": true,
+            "value": "#ff0000"
+        },
+        "color-3": {
+            "label": "Color 3",
+            "path": "config.presets.3",
+            "type": "input",
+            "format": "hexColorCode",
+            "required": true,
+            "value": "#0034ff"
+        }        
+    }
+}

--- a/configurations/modules/mast_module.json
+++ b/configurations/modules/mast_module.json
@@ -1,19 +1,18 @@
 {
-    "type": "hvac",
+    "type": "mast",
     "fields": {
         "displayName": {
             "label": "Display Name",
             "path": "meta.id",
             "additionalPaths": ["id"],
             "type": "input",
-            "required": true,
-            "value": "hvac"
+            "value": "Masts"
         },
         "name": {
             "label": "Name",
             "path": "name",
             "type": "translation",
-            "value": { "value": "modules.hvac.name" }
+            "value": { "value": "modules.mast.name" }
         },
         "type": {
             "label": "Type",
@@ -21,7 +20,7 @@
             "type": "dropdown",
             "values": "moduleTypes",
             "readonly": true,
-            "value": "hvac"
+            "value": "mast"
         },
         "systemIds": {
             "label": "Systems",
@@ -29,6 +28,12 @@
             "type": "multiselect",
             "values": "existingSystemsForModule",
             "value": []
+        },
+        "config": {
+            "label": "Simultaneous Control",
+            "path": "config.simultaneousControl",
+            "type": "switch",
+            "value": false
         }
     }
 }

--- a/configurations/modules/powerSource_module.json
+++ b/configurations/modules/powerSource_module.json
@@ -1,19 +1,18 @@
 {
-	"type": "awning",	
-	"last_updated": "2024/09/04",
-	"fields": {
-            "displayName": {
+    "type": "powerSource",
+    "fields": {
+       "displayName": {
                 "label": "Display Name",
                 "path": "meta.id",
                 "additionalPaths": ["id"],
                 "type": "input",
-                "value": "Awning"
+                "value": "Power Source"
             },
             "name": {
                 "label": "Name",
                 "path": "name",
                 "type": "translation",
-                "value": { "value": "modules.awning.name" }
+                "value": { "value": "modules.shorePower.name" }
             },
             "type": {
                 "label": "Type",
@@ -21,7 +20,7 @@
                 "type": "dropdown",
                 "values": "moduleTypes",
                 "readonly": true,
-                "value": "Awning"
+                "value": "powerSource"
             },
             "systemIds": {
                 "label": "Systems",
@@ -30,5 +29,5 @@
                 "values": "existingSystemsForModule",
                 "value": []
             }
-        }
+    }
 }

--- a/configurations/modules/rackControl_module.json
+++ b/configurations/modules/rackControl_module.json
@@ -1,19 +1,18 @@
 {
-    "type": "hvac",
+    "type": "rackControl",
     "fields": {
         "displayName": {
             "label": "Display Name",
             "path": "meta.id",
             "additionalPaths": ["id"],
             "type": "input",
-            "required": true,
-            "value": "hvac"
+            "value": "Rack Control"
         },
         "name": {
             "label": "Name",
             "path": "name",
             "type": "translation",
-            "value": { "value": "modules.hvac.name" }
+            "value": { "value": "modules.rackControl.name" }
         },
         "type": {
             "label": "Type",
@@ -21,7 +20,7 @@
             "type": "dropdown",
             "values": "moduleTypes",
             "readonly": true,
-            "value": "hvac"
+            "value": "Rack Control"
         },
         "systemIds": {
             "label": "Systems",

--- a/configurations/modules/sensor_module.json
+++ b/configurations/modules/sensor_module.json
@@ -1,19 +1,18 @@
 {
-    "type": "hvac",
+    "type": "sensor",
     "fields": {
         "displayName": {
             "label": "Display Name",
             "path": "meta.id",
             "additionalPaths": ["id"],
             "type": "input",
-            "required": true,
-            "value": "hvac"
+            "value": "Sensor"
         },
         "name": {
             "label": "Name",
             "path": "name",
             "type": "translation",
-            "value": { "value": "modules.hvac.name" }
+            "value": { "value": "modules.sensor.name" }
         },
         "type": {
             "label": "Type",
@@ -21,7 +20,7 @@
             "type": "dropdown",
             "values": "moduleTypes",
             "readonly": true,
-            "value": "hvac"
+            "value": "Sensor"
         },
         "systemIds": {
             "label": "Systems",

--- a/configurations/modules/slideout_module.json
+++ b/configurations/modules/slideout_module.json
@@ -1,19 +1,18 @@
 {
-	"type": "awning",	
-	"last_updated": "2024/09/04",
-	"fields": {
-            "displayName": {
+    "type": "slideout",
+    "fields": {
+        "displayName": {
                 "label": "Display Name",
                 "path": "meta.id",
                 "additionalPaths": ["id"],
                 "type": "input",
-                "value": "Awning"
+                "value": "Slideout"
             },
             "name": {
                 "label": "Name",
                 "path": "name",
                 "type": "translation",
-                "value": { "value": "modules.awning.name" }
+                "value": { "value": "modules.slideout.name" }
             },
             "type": {
                 "label": "Type",
@@ -21,7 +20,7 @@
                 "type": "dropdown",
                 "values": "moduleTypes",
                 "readonly": true,
-                "value": "Awning"
+                "value": "Slideout"
             },
             "systemIds": {
                 "label": "Systems",
@@ -30,5 +29,5 @@
                 "values": "existingSystemsForModule",
                 "value": []
             }
-        }
+    }
 }

--- a/configurations/modules/testModules.json
+++ b/configurations/modules/testModules.json
@@ -1,4 +1,0 @@
-{
-    "text": "Hey! I am some testing module!",
-    "type": "testModule"
-}

--- a/configurations/modules/ups_module.json
+++ b/configurations/modules/ups_module.json
@@ -1,19 +1,18 @@
 {
-    "type": "hvac",
+    "type": "ups",
     "fields": {
         "displayName": {
             "label": "Display Name",
             "path": "meta.id",
             "additionalPaths": ["id"],
             "type": "input",
-            "required": true,
-            "value": "hvac"
+            "value": "UPS"
         },
         "name": {
             "label": "Name",
             "path": "name",
             "type": "translation",
-            "value": { "value": "modules.hvac.name" }
+            "value": { "value": "modules.ups.name" }
         },
         "type": {
             "label": "Type",
@@ -21,7 +20,7 @@
             "type": "dropdown",
             "values": "moduleTypes",
             "readonly": true,
-            "value": "hvac"
+            "value": "UPS"
         },
         "systemIds": {
             "label": "Systems",

--- a/configurations/modules/vsat_module.json
+++ b/configurations/modules/vsat_module.json
@@ -1,19 +1,18 @@
 {
-    "type": "hvac",
+    "type": "vsat",
     "fields": {
         "displayName": {
             "label": "Display Name",
             "path": "meta.id",
             "additionalPaths": ["id"],
             "type": "input",
-            "required": true,
-            "value": "hvac"
+            "value": "VSAT"
         },
         "name": {
             "label": "Name",
             "path": "name",
             "type": "translation",
-            "value": { "value": "modules.hvac.name" }
+            "value": { "value": "modules.vsat.name" }
         },
         "type": {
             "label": "Type",
@@ -21,7 +20,7 @@
             "type": "dropdown",
             "values": "moduleTypes",
             "readonly": true,
-            "value": "hvac"
+            "value": "VSAT"
         },
         "systemIds": {
             "label": "Systems",

--- a/configurations/modules/weatherStation_module.json
+++ b/configurations/modules/weatherStation_module.json
@@ -1,19 +1,18 @@
 {
-    "type": "hvac",
+    "type": "weatherStation",
     "fields": {
         "displayName": {
             "label": "Display Name",
             "path": "meta.id",
             "additionalPaths": ["id"],
             "type": "input",
-            "required": true,
-            "value": "hvac"
+            "value": "Weather Station"
         },
         "name": {
             "label": "Name",
             "path": "name",
             "type": "translation",
-            "value": { "value": "modules.hvac.name" }
+            "value": { "value": "modules.weatherStation.name" }
         },
         "type": {
             "label": "Type",
@@ -21,7 +20,7 @@
             "type": "dropdown",
             "values": "moduleTypes",
             "readonly": true,
-            "value": "hvac"
+            "value": "Weather Station"
         },
         "systemIds": {
             "label": "Systems",

--- a/configurations/systems/awning_system.json
+++ b/configurations/systems/awning_system.json
@@ -1,0 +1,92 @@
+{
+	"type": "awning",	
+	"last_updated": "2024/09/04",
+	"fields": {
+		"displayName": {
+			"label": "Display Name",
+			"path": "meta.id",
+			"additionalPaths": ["id"],
+			"type": "input",
+			"value": "Awning System"
+		},
+		"type": {
+			"label": "Type",
+			"path": "type",
+			"type": "dropdown",
+			"values": "systemTypes",
+			"readonly": true,
+			"value": "Awning"
+		},
+		"separator-1": {
+			"type": "separator"
+		},
+		"name": {
+			"label": "Name",
+			"path": "name",
+			"type": "translation",
+			"value": { "value": "modules.awning.name" }
+		},
+		"separator-2": {
+			"type": "separator"
+		},
+		"hardwareTimeoutDeploy": {
+			"label": "Timeout for Extend (ms)",
+			"path": "hardware.timeouts.extend",
+			"type": "input",
+			"value": "0",
+			"group": 1
+		},
+		"hardwareTimeoutStow": {
+			"label": "Timeout for Retract (ms)",
+			"path": "hardware.timeouts.retract",
+			"type": "input",
+			"value": "0",
+			"group": 1
+		},
+		"separator-3": {
+			"type": "separator"
+		},
+		"hardwareActionsExtend": {
+			"label": "Action - Extend (int)",
+			"path": "hardware.actions.extend",
+			"type": "input",
+			"value": "1",
+			"group": 2
+		},
+		"hardwareActionsRetract": {
+			"label": "Action - Retract (int)",
+			"path": "hardware.actions.retract",
+			"type": "input",
+			"value": "1",
+			"group": 2
+		},
+		"hardwareActionsStop": {
+			"label": "Action - Stop (int)",
+			"path": "hardware.actions.stop",
+			"type": "input",
+			"value": "0",
+			"group": 2
+		},
+		"separator-4": {
+			"type": "separator"
+		},
+		"hardwareOutputs": {
+			"label": "Outputs",
+			"path": "hardware.outputs",
+			"type": "hardwareOutputs",
+			"value": []
+		},
+		"triggers": {
+			"label": "Triggers",
+			"path": "triggers",
+			"type": "triggers",
+			"value": []
+		},
+		"preconditions": {
+			"label": "Preconditions",
+			"path": "preconditions",
+			"type": "preconditions",
+			"value": []
+		}
+	}
+}

--- a/configurations/systems/batteryMonitor_system.json
+++ b/configurations/systems/batteryMonitor_system.json
@@ -1,0 +1,124 @@
+ {
+    "type": "batteryMonitor", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Battery Monitor"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "batteryMonitor"
+        },
+        "separator-0": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.batteryMonitor.name" }
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "configVoltageBoundsMin": {
+            "label": "Voltage - Bounds - Min",
+            "path": "config.voltage.bounds.min",
+            "type": "input",
+            "value": "9.0",
+            "group": 1
+        },
+        "configVoltageBoundsMax": {
+            "label": "Voltage - Bounds - Max",
+            "path": "config.voltage.bounds.max",
+            "type": "input",
+            "value": 16.0,
+            "group": 1
+        },
+        "configVoltageSafeBoundsMin": {
+            "label": "Voltage - Safe Bounds - Min",
+            "path": "config.voltage.safeBounds.min",
+            "type": "input",
+            "value": "11.0",
+            "group": 1
+        },
+        "configVoltageSafeBoundsMax": {
+            "label": "Voltage - Safe Bounds - Max",
+            "path": "config.voltage.safeBounds.max",
+            "type": "input",
+            "value": "14.0",
+            "group": 1
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "configCurrentBoundsMin": {
+            "label": "Current - Bounds - Min",
+            "path": "config.current.bounds.min",
+            "type": "input",
+            "value": -120.0,
+            "group": 2
+        },
+        "configCurrentBoundsMax": {
+            "label": "Current - Bounds - Max",
+            "path": "config.current.bounds.max",
+            "type": "input",
+            "value": 120.0,
+            "group": 2
+        },
+        "configCurrentSafeBoundsMin": {
+            "label": "Current - Safe Bounds - Min",
+            "path": "config.current.safeBounds.min",
+            "type": "input",
+            "value": -100.0,
+            "group": 2
+        },
+        "configCurrentSafeBoundsMax": {
+            "label": "Current - Safe Bounds - Max",
+            "path": "config.current.safeBounds.max",
+            "type": "input",
+            "value": 100.0,
+            "group": 2
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "hardwareSource": {
+            "label": "source",
+            "path": "hardware.source",
+            "type": "input",
+            "value": "nti",
+            "group": 3
+        },
+        "hardwareIndex": {
+            "label": "index",
+            "path": "hardware.index",
+            "type": "input",
+            "value": "1",
+            "group": 3
+        },
+        "separator-4": {
+            "type": "separator"
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/generator_system.json
+++ b/configurations/systems/generator_system.json
@@ -1,0 +1,68 @@
+ {
+    "type": "generator", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Generator"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "mast"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.generator.name" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "hardwareSource": {
+            "label": "source",
+            "path": "hardware.source",
+            "type": "input",
+            "value": "nti",
+            "group": 1
+        },
+        "hardwareIndex": {
+            "label": "index",
+            "path": "hardware.index",
+            "type": "input",
+            "value": "2",
+            "group": 1
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/hvac_system.json
+++ b/configurations/systems/hvac_system.json
@@ -1,0 +1,72 @@
+ {
+    "type": "hvac", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "hvac"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "hvac"
+        },
+        "separator-0": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.hvac.name" }
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "modes": {
+            "label": "Modes",
+            "path": "config.modes",
+            "type": "multiselect",
+            "defaultOptions": ["auto", "cool", "heat", "off"]
+        },
+        "fanSpeeds": {
+            "label": "Fan Speeds",
+            "path": "config.fanSpeeds",
+            "type": "multiselect",
+            "defaultOptions": ["auto", "high", "medium", "low"]
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Inputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "exclusions": {
+            "label": "Exclusions",
+            "path": "hardware.exclusions",
+            "type": "exclusions",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/interlock_system.json
+++ b/configurations/systems/interlock_system.json
@@ -1,0 +1,115 @@
+{
+    "type": "interlock", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "required": false,
+            "value": "Interlock"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "interlock"
+        },
+        "group": {
+            "label": "Group",
+            "path": "hardware.group",
+            "type": "input",
+            "format": "string",
+            "required": false,
+            "value": ""
+        },
+        "separator-0": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.interlock.name" }
+        },
+        "location": {
+            "label": "Location",
+            "path": "config.location",
+            "type": "translation",
+            "value": { "value": "location.other" }
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Inputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "exclusions": {
+            "label": "Exclusions",
+            "path": "hardware.exclusions",
+            "type": "exclusions",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "x": {
+            "label": "X position",
+            "path": "config.x",
+            "type": "input",
+            "format": "int",
+            "value": 0,
+            "group": 1
+        },
+        "y": {
+            "label": "Y position",
+            "path": "config.y",
+            "type": "input",
+            "format": "int",
+            "value": 0,
+            "group": 1
+        },
+        "height": {
+            "label": "height",
+            "path": "config.height",
+            "type": "input",
+            "format": "int",
+            "value": 0,
+            "group": 1
+        },
+        "width": {
+            "label": "width",
+            "path": "config.width",
+            "type": "input",
+            "format": "int",
+            "value": 0,
+            "group": 1
+        },
+        "rotation": {
+            "label": "rotation",
+            "path": "config.rotation",
+            "type": "input",
+            "format": "int",
+            "value": 0,
+            "group": 1
+        }
+    }
+}

--- a/configurations/systems/leveling_system.json
+++ b/configurations/systems/leveling_system.json
@@ -1,0 +1,63 @@
+{
+    "type": "leveling", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Leveling"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "mast"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.leveling.name" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Inputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "exclusions": {
+            "label": "Exclusions",
+            "path": "hardware.exclusions",
+            "type": "exclusions",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/light_system.json
+++ b/configurations/systems/light_system.json
@@ -1,0 +1,119 @@
+{
+    "type": "light", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "format": "string",
+            "required": false,
+            "value": "Lights"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "format": "string",
+            "values": "systemTypes",
+            "required": true,
+            "readonly": true,
+            "value": "light"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.light.name" }
+        },
+        "location": {
+            "label": "Location",
+            "path": "config.location",
+            "type": "translation",
+            "value": { "value": "location.other" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "color": {
+            "label": "Color",
+            "path": "config.color",
+            "type": "switch",
+            "format": "boolean",
+            "value": true
+        },
+        "brightness": {
+            "label": "Brightness",
+            "path": "config.brightness",
+            "type": "switch",
+            "format": "boolean",
+            "value": true
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "status": {
+            "label": "Status",
+            "path": "state.status",
+            "type": "input",
+            "format": "text",
+            "value": "off"
+        },
+        "presetId": {
+            "label": "Preset Id",
+            "path": "state.presetId",
+            "type": "input",
+            "format": "number",
+            "value": 0
+        },
+        "brightnessValue": {
+            "label": "Brightness Value",
+            "path": "state.brightness",
+            "type": "input",
+            "format": "double",
+            "value": 0
+        },
+        "separator-4": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "hardwareInputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "format": "array",
+            "value": []
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "format": "array",
+            "value": []
+        },
+        "exclusions": {
+            "label": "Exclusions",
+            "path": "hardware.exclusions",
+            "type": "exclusions",
+            "format": "array",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "format": "object",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "format": "array",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/mast_system.json
+++ b/configurations/systems/mast_system.json
@@ -1,0 +1,72 @@
+{
+    "type": "mast", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Mast"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "mast"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.mast.name" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "height": {
+            "label": "Height",
+            "path": "config.height",
+            "type": "switch",
+            "value": false
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Inputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "exclusions": {
+            "label": "Exclusions",
+            "path": "hardware.exclusions",
+            "type": "exclusions",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/newSystem.json
+++ b/configurations/systems/newSystem.json
@@ -1,4 +1,0 @@
-{
-    "text": "This is a new system",
-    "type": "newtSystem"
-}

--- a/configurations/systems/newSystem.json
+++ b/configurations/systems/newSystem.json
@@ -1,0 +1,4 @@
+{
+    "text": "This is a new system",
+    "type": "newtSystem"
+}

--- a/configurations/systems/powerSource_system.json
+++ b/configurations/systems/powerSource_system.json
@@ -1,0 +1,159 @@
+{
+    "type": "powerSource", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Power Source"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "powerSource"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.shorePower.name" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "configVoltageBoundsMin": {
+            "label": "Voltage - Bounds - Min",
+            "path": "config.voltage.bounds.min",
+            "type": "input",
+            "value": "90.0",
+            "group": 1
+        },
+        "configVoltageBoundsMax": {
+            "label": "Voltage - Bounds - Max",
+            "path": "config.voltage.bounds.max",
+            "type": "input",
+            "value": 150.0,
+            "group": 1
+        },
+        "configVoltageSafeBoundsMin": {
+            "label": "Voltage - Safe Bounds - Min",
+            "path": "config.voltage.safeBounds.min",
+            "type": "input",
+            "value": "110.0",
+            "group": 1
+        },
+        "configVoltageSafeBoundsMax": {
+            "label": "Voltage - Safe Bounds - Max",
+            "path": "config.voltage.safeBounds.max",
+            "type": "input",
+            "value": "130.0",
+            "group": 1
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "configCurrentBoundsMin": {
+            "label": "Current - Bounds - Min",
+            "path": "config.current.bounds.min",
+            "type": "input",
+            "value": 0.0,
+            "group": 2
+        },
+        "configCurrentBoundsMax": {
+            "label": "Current - Bounds - Max",
+            "path": "config.current.bounds.max",
+            "type": "input",
+            "value": 100.0,
+            "group": 2
+        },
+        "configCurrentSafeBoundsMin": {
+            "label": "Current - Safe Bounds - Min",
+            "path": "config.current.safeBounds.min",
+            "type": "input",
+            "value": 0.0,
+            "group": 2
+        },
+        "configCurrentSafeBoundsMax": {
+            "label": "Current - Safe Bounds - Max",
+            "path": "config.current.safeBounds.max",
+            "type": "input",
+            "value": 80.0,
+            "group": 2
+        },
+        "separator-4": {
+            "type": "separator"
+        },
+        "configFrequencyBoundsMin": {
+            "label": "Frequency - Bounds - Min",
+            "path": "config.frequency.bounds.min",
+            "type": "input",
+            "value": 55.0,
+            "group": 3
+        },
+        "configFrequencyBoundsMax": {
+            "label": "Frequency - Bounds - Max",
+            "path": "config.frequency.bounds.max",
+            "type": "input",
+            "value": 65.0,
+            "group": 3
+        },
+        "configFrequencySafeBoundsMin": {
+            "label": "Frequency - Safe Bounds - Min",
+            "path": "config.frequency.safeBounds.min",
+            "type": "input",
+            "value": 58.0,
+            "group": 3
+        },
+        "configFrequencySafeBoundsMax": {
+            "label": "Frequency - Safe Bounds - Max",
+            "path": "config.frequency.safeBounds.max",
+            "type": "input",
+            "value": 62.0,
+            "group": 3
+        },
+        "separator-5": {
+            "type": "separator"
+        },
+        "hardwareSerialNumber": {
+            "label": "sn",
+            "path": "hardware.sn",
+            "type": "input",
+            "value": "000-000-000"
+        },
+        "separator-6": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Inputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/rackControl_system.json
+++ b/configurations/systems/rackControl_system.json
@@ -1,0 +1,129 @@
+{
+    "type": "rackControl", 
+    "last_updated": "2024/09/04",
+   "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Rack Control System"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "Rack Control"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.rackControl.name" }
+        },
+        "location": {
+            "label": "Location",
+            "path": "config.location",
+            "type": "translation",
+            "value": { "value": "location.other" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "hardwareActionsOn": {
+            "label": "Action - On (int)",
+            "path": "hardware.actions.on",
+            "type": "input",
+            "value": "1",
+            "group": 4
+        },
+        "hardwareActionsOff": {
+            "label": "Action - Off (int)",
+            "path": "hardware.actions.off",
+            "type": "input",
+            "value": "0",
+            "group": 4
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "hardwareOutputSelectionValue": {
+            "label": "Hardware Output - Selection Value",
+            "path": "hardware.outputs.selection.value",
+            "type": "input",
+            "value": "1",
+            "group": 1
+        },
+        "hardwareOutputSelectionUnit": {
+            "label": "Hardware Output - Selection Unit",
+            "path": "hardware.outputs.selection.unit",
+            "type": "input",
+            "value": "1",
+            "group": 1
+        },
+        "hardwareOutputSelectionBlock": {
+            "label": "Hardware Output - Selection Block",
+            "path": "hardware.outputs.selection.block",
+            "type": "input",
+            "value": "1",
+            "group": 1
+        },
+        "hardwareOutputSelectionBit": {
+            "label": "Hardware Output - Selection Bit",
+            "path": "hardware.outputs.selection.bit",
+            "type": "input",
+            "value": "2",
+            "group": 1
+        },
+        "separator-4": {
+            "type": "separator"
+        },
+        "hardwareOutputPowerUnit": {
+            "label": "Hardware Output - Power Unit",
+            "path": "hardware.outputs.power.unit",
+            "type": "input",
+            "value": "1",
+            "group": 2
+        },
+        "hardwareOutputPowerBlock": {
+            "label": "Hardware Output - Power Block",
+            "path": "hardware.outputs.power.block",
+            "type": "input",
+            "value": "1",
+            "group": 2
+        },
+        "hardwareOutputPowerBit": {
+            "label": "Hardware Output - Power Bit",
+            "path": "hardware.outputs.power.bit",
+            "type": "input",
+            "value": "3",
+            "group": 2
+        },
+        "separator-5": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Outputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/sensor_system.json
+++ b/configurations/systems/sensor_system.json
@@ -1,0 +1,112 @@
+{
+    "type": "sensor", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Sensor System"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "Sensor"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.sensor.name" }
+        },
+        "location": {
+            "label": "Location",
+            "path": "config.location",
+            "type": "translation",
+            "value": { "value": "location.other" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "configAlertThreshold": {
+            "label": "Alert Threshold",
+            "path": "config.alertThreshold",
+            "type": "input",
+            "value": 1
+        },
+        "configSensorSubType": {
+            "label": "Type of Sensor",
+            "path": "config.type",
+            "type": "dropdown",
+            "values": "sensorTypes",
+            "value": "temperature"
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "hardwareSource": {
+            "label": "Source",
+            "path": "hardware.source",
+            "type": "input",
+            "value": "mqtt",
+            "readonly": true,
+            "group": 1
+        },
+        "hardwareMQTTEventType": {
+            "label": "MQTT Event - Type",
+            "path": "hardware.event.type",
+            "type": "input",
+            "value": "sensor",
+            "readonly": true,
+            "group": 1
+        },
+        "hardwareMQTTEventLog": {
+            "label": "MQTT Event - Logged?",
+            "path": "hardware.event.log",
+            "type": "switch",
+            "value": true,
+            "group": 1
+        },
+        "separator-5": {
+            "type": "separator"
+        },
+        "hardwareMQTTTopic": {
+            "label": "MQTT Topic - (must match Type of Sensor)",
+            "path": "hardware.topic",
+            "type": "dropdown",
+            "values": "sensorTypes",
+            "value": "temperature",
+            "group": 1
+        },
+        "hardwareMQTTEventKey": {
+            "label": "MQTT Key - (must match Type of Sensor)",
+            "path": "hardware.event.key",
+            "type": "dropdown",
+            "values": "sensorTypes",
+            "value": "temperature",
+            "group": 1
+        },
+        "separator-4": {
+            "type": "separator"
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/slideout_system.json
+++ b/configurations/systems/slideout_system.json
@@ -1,0 +1,103 @@
+{
+    "type": "slideout", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Slideout System"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "Slideout"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.slideout.name" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "hardwareTimeoutDeploy": {
+            "label": "Timeout for Extend (ms)",
+            "path": "hardware.timeouts.extend",
+            "type": "input",
+            "format": "int",
+            "value": "0",
+            "group": 2
+        },
+        "hardwareTimeoutStow": {
+            "label": "Timeout for Retract (ms)",
+            "path": "hardware.timeouts.retract",
+            "type": "input",
+            "format": "int",
+            "value": "0",
+            "group": 2
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "hardwareActionsExtend": {
+            "label": "Action - Extend (int)",
+            "path": "hardware.actions.extend",
+            "type": "input",
+            "format": "int",
+            "value": "1",
+            "group": 1
+        },
+        "hardwareActionsRetract": {
+            "label": "Action - Retract (int)",
+            "path": "hardware.actions.retract",
+            "type": "input",
+            "format": "int",
+            "value": "1",
+            "group": 1
+        },
+        "hardwareActionsStop": {
+            "label": "Action - Stop (int)",
+            "path": "hardware.actions.stop",
+            "type": "input",
+            "format": "int",
+            "value": "0",
+            "group": 1
+        },
+        "separator-4": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Inputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/testSystem.json
+++ b/configurations/systems/testSystem.json
@@ -1,4 +1,0 @@
-{
-    "text": "Hey! I am some testing system!",
-    "type": "testSystem"
-}

--- a/configurations/systems/ups_system.json
+++ b/configurations/systems/ups_system.json
@@ -1,0 +1,68 @@
+{
+    "type": "ups", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "UPS"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "batteryMonitor"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.ups.name" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "hardwareSource": {
+            "label": "source",
+            "path": "hardware.source",
+            "type": "input",
+            "value": "nti",
+            "group": 1
+        },
+        "hardwareIndex": {
+            "label": "index",
+            "path": "hardware.index",
+            "type": "input",
+            "value": "1",
+            "group": 1
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Inputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/vsat_system.json
+++ b/configurations/systems/vsat_system.json
@@ -1,0 +1,82 @@
+{
+    "type": "vsat", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "VSAT System"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "VSAT"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.vsat.name" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "hardwareTimeoutDeploy": {
+            "label": "Timeout for Deploy (ms)",
+            "path": "hardware.timeouts.deploy",
+            "type": "input",
+            "value": "0",
+            "group": 1
+        },
+        "hardwareTimeoutStow": {
+            "label": "Timeout for Stow (ms)",
+            "path": "hardware.timeouts.stow",
+            "type": "input",
+            "value": "0",
+            "group": 1
+        },
+        "hardwareActionsDeploy": {
+            "label": "Action - Deploy (int)",
+            "path": "hardware.actions.deploy",
+            "type": "input",
+            "value": "1",
+            "group": 1
+        },
+        "hardwareActionsStow": {
+            "label": "Action - Stow (int)",
+            "path": "hardware.actions.stow",
+            "type": "input",
+            "value": "0",
+            "group": 1
+        },
+        "separator-3": {
+            "type": "separator"
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/configurations/systems/weatherStation_system.json
+++ b/configurations/systems/weatherStation_system.json
@@ -1,0 +1,57 @@
+{
+    "type": "weatherStation", 
+    "last_updated": "2024/09/04",
+    "fields": {
+        "displayName": {
+            "label": "Display Name",
+            "path": "meta.id",
+            "additionalPaths": ["id"],
+            "type": "input",
+            "value": "Weather Station System"
+        },
+        "type": {
+            "label": "Type",
+            "path": "type",
+            "type": "dropdown",
+            "values": "systemTypes",
+            "readonly": true,
+            "value": "Weather Station"
+        },
+        "separator-1": {
+            "type": "separator"
+        },
+        "name": {
+            "label": "Name",
+            "path": "name",
+            "type": "translation",
+            "value": { "value": "modules.weatherStation.name" }
+        },
+        "separator-2": {
+            "type": "separator"
+        },
+        "hardwareInputs": {
+            "label": "Inputs",
+            "path": "hardware.inputs",
+            "type": "hardwareInputs",
+            "value": []
+        },
+        "hardwareOutputs": {
+            "label": "Outputs",
+            "path": "hardware.outputs",
+            "type": "hardwareOutputs",
+            "value": []
+        },
+        "triggers": {
+            "label": "Triggers",
+            "path": "triggers",
+            "type": "triggers",
+            "value": []
+        },
+        "preconditions": {
+            "label": "Preconditions",
+            "path": "preconditions",
+            "type": "preconditions",
+            "value": []
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "i18next": "^23.7.16",
         "i18next-browser-languagedetector": "^7.2.0",
         "i18next-http-backend": "^2.4.2",
+        "moment": "^2.30.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^13.5.0"
@@ -7297,6 +7298,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "css-loader": "^6.11.0",
     "electron": "30.0.6",
     "node-loader": "^2.0.0",
-    "style-loader": "^3.3.4"    
+    "style-loader": "^3.3.4"
   },
   "keywords": [],
   "author": {
@@ -38,13 +38,6 @@
   "license": "MIT",
   "dependencies": {
     "@bmunozg/react-image-area": "^1.1.0",
-    "electron-squirrel-startup": "^1.0.1",
-    "i18next": "^23.7.16",
-    "i18next-browser-languagedetector": "^7.2.0",
-    "i18next-http-backend": "^2.4.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-i18next": "^13.5.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@hookform/error-message": "^2.0.1",
@@ -54,6 +47,14 @@
     "@mui/material": "^5.15.4",
     "@mui/utils": "^5.15.4",
     "@mui/x-data-grid": "^6.18.7",
-    "@mui/x-date-pickers": "^6.19.0"
+    "@mui/x-date-pickers": "^6.19.0",
+    "electron-squirrel-startup": "^1.0.1",
+    "i18next": "^23.7.16",
+    "i18next-browser-languagedetector": "^7.2.0",
+    "i18next-http-backend": "^2.4.2",
+    "moment": "^2.30.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-i18next": "^13.5.0"
   }
 }

--- a/src/webapps/configBuilder/ConfigBuilder.jsx
+++ b/src/webapps/configBuilder/ConfigBuilder.jsx
@@ -8,6 +8,7 @@ export default function ConfigBuilder() {
   const [modules, setModules] = useState(null)
   const [systems, setSystems] = useState(null)
   const [schema, setSchema] = useState(null)
+  const [availableFiles, setAvailableFiles] = useState([]);
 
   async function getFromMain() {
     setModules(await window.electronAPI.getFolder('modules'))
@@ -16,6 +17,12 @@ export default function ConfigBuilder() {
 
   async function openFolder() {
     await window.electronAPI.showItemInFolder('C:\\Users\\john.bissen\\VS Projects\\NTC-Hardware-Utilities\\configurations\\modules')
+  }
+  
+  async function listFiles() {
+    let fileList = await window.electronAPI.listFilesInFolder();
+    console.log('File List: ', fileList);
+    setAvailableFiles(fileList);
   }
 
   useEffect(() => {
@@ -39,6 +46,7 @@ export default function ConfigBuilder() {
       <div>
         <button onClick={getFromMain}>Get Files</button>
         <button onClick={openFolder}>Open Folder</button>
+        <button onClick={listFiles}>List Files</button>
       </div>    
       <ConfigBuilderPage></ConfigBuilderPage>
     </div>   

--- a/src/webapps/configBuilder/ConfigBuilder.jsx
+++ b/src/webapps/configBuilder/ConfigBuilder.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import ConfigBuilderPage from './src/ConfigBuilderPage.jsx';
 import {Box, Stack} from "@mui/material";
 import './i18n/i18n.js';
@@ -7,6 +7,7 @@ import './i18n/i18n.js';
 export default function ConfigBuilder() {
   const [modules, setModules] = useState(null)
   const [systems, setSystems] = useState(null)
+  const [schema, setSchema] = useState(null)
 
   async function getFromMain() {
     setModules(await window.electronAPI.getFolder('modules'))
@@ -17,8 +18,21 @@ export default function ConfigBuilder() {
     await window.electronAPI.showItemInFolder('C:\\Users\\john.bissen\\VS Projects\\NTC-Hardware-Utilities\\configurations\\modules')
   }
 
-  console.log(modules)
-  console.log(systems)
+  useEffect(() => {
+    if (modules && systems) {
+      const newSchema = {
+        "version": "0.9.2",
+        "templateVersion": "0.0.1",
+        "modules": modules,
+        "systems": systems
+      }
+      setSchema(newSchema);
+    }
+  }, [modules, systems])
+
+  console.log(modules);
+  console.log(systems);
+  console.log(schema);
 
   return (       
     <div name='config-builder-component' style={{height:'100%', background: 'white', borderRadius: '7px'}}>  

--- a/src/webapps/configBuilder/ConfigBuilder.jsx
+++ b/src/webapps/configBuilder/ConfigBuilder.jsx
@@ -13,10 +13,19 @@ export default function ConfigBuilder() {
     setSystems(await window.electronAPI.getFolder('systems'))
   }
 
+  async function openFolder() {
+    await window.electronAPI.showItemInFolder('C:\\Users\\john.bissen\\VS Projects\\NTC-Hardware-Utilities\\configurations\\modules')
+  }
+
   console.log(modules)
   console.log(systems)
+
   return (       
-    <div name='config-builder-component' style={{height:'100%', background: 'white', borderRadius: '7px'}}>      
+    <div name='config-builder-component' style={{height:'100%', background: 'white', borderRadius: '7px'}}>  
+      <div>
+        <button onClick={getFromMain}>Get Files</button>
+        <button onClick={openFolder}>Open Folder</button>
+      </div>    
       <ConfigBuilderPage></ConfigBuilderPage>
     </div>   
   )

--- a/src/webapps/configBuilder/ConfigBuilder.jsx
+++ b/src/webapps/configBuilder/ConfigBuilder.jsx
@@ -4,11 +4,36 @@ import {Box, Stack} from "@mui/material";
 import './i18n/i18n.js';
 
 
-export default function ConfigBuilder() {
+export default function ConfigBuilder({assetConfigJSON}) {
   const [modules, setModules] = useState(null)
   const [systems, setSystems] = useState(null)
   const [schema, setSchema] = useState(null)
   const [availableFiles, setAvailableFiles] = useState([]);
+
+  // -------------------------------------------------------------------------------------------------
+  // USE EFFECTS
+  // -------------------------------------------------------------------------------------------------
+  
+  useEffect(() => {
+    getFromMain();
+  }, [])
+
+  useEffect(() => {
+    if (modules && systems) {
+      const newSchema = {
+        "version": "0.9.2",
+        "templateVersion": "0.0.1",
+        "modules": modules,
+        "systems": systems
+      }
+      setSchema(newSchema);
+    }
+  }, [modules, systems])
+
+  
+  // -------------------------------------------------------------------------------------------------
+  // FUNCTIONS
+  // -------------------------------------------------------------------------------------------------
 
   async function getFromMain() {
     setModules(await window.electronAPI.getFolder('modules'))
@@ -25,30 +50,17 @@ export default function ConfigBuilder() {
     setAvailableFiles(fileList);
   }
 
-  useEffect(() => {
-    if (modules && systems) {
-      const newSchema = {
-        "version": "0.9.2",
-        "templateVersion": "0.0.1",
-        "modules": modules,
-        "systems": systems
-      }
-      setSchema(newSchema);
-    }
-  }, [modules, systems])
-
-  console.log(modules);
-  console.log(systems);
-  console.log(schema);
+  console.log("Modules: ", modules);
+  console.log("Systems: ", systems);
+  console.log("Schema: ", schema);
 
   return (       
     <div name='config-builder-component' style={{height:'100%', background: 'white', borderRadius: '7px'}}>  
-      <div>
-        <button onClick={getFromMain}>Get Files</button>
-        <button onClick={openFolder}>Open Folder</button>
-        <button onClick={listFiles}>List Files</button>
-      </div>    
-      <ConfigBuilderPage></ConfigBuilderPage>
+      {schema ? 
+        <ConfigBuilderPage assetConfigJSON={assetConfigJSON} schemaJSON={schema}></ConfigBuilderPage>      
+        :
+        <div>Loading Schemas.  Please wait.</div>
+      }
     </div>   
   )
 }

--- a/src/webapps/configBuilder/index.css
+++ b/src/webapps/configBuilder/index.css
@@ -58,3 +58,20 @@ body {
 
   background-color: beige;
 }
+
+
+#assetConfigLoader td, #assetConfigLoader th {
+  text-align: center;
+  border-bottom: 1px solid #ccc
+}
+#assetConfigLoader tr:last-of-type td {
+  border-bottom: 0px solid #ccc;
+}
+#assetConfigLoader tr.hoverable:hover {
+  background-color: #abe7a0;  
+  cursor: pointer;
+}
+#assetConfigLoader tr.invalid {
+  background-color: #f5dada;  
+  cursor: default;
+}

--- a/src/webapps/configBuilder/index.html
+++ b/src/webapps/configBuilder/index.html
@@ -5,6 +5,6 @@
     <title>Config Builder</title>
   </head>
   <body>   
-    <p>This is static html</p>
+    <p>Please wait while config builder loads</p>
   </body>
 </html>

--- a/src/webapps/configBuilder/mainPage.jsx
+++ b/src/webapps/configBuilder/mainPage.jsx
@@ -3,36 +3,56 @@ import ConfigBuilder from './ConfigBuilder.jsx';
 
 import './index.css';
 
-//add all other config pages to this file
+// TODO:  add all other config pages to this file
+
+// -------------------------------------------------------------------------------------------------
+// Summary:
+// On start up, check if any asset-configs exist in asset-configs directory, and display them.  
+// when selected, load the config builder page.
+// -------------------------------------------------------------------------------------------------
 function MainPage() {
   const [selectedAssetConfig, setSelectedAssetConfig] = useState(null);
   const [availableFiles, setAvailableFiles] = useState([]);
+
+  // -------------------------------------------------------------------------------------------------
+  // USE EFFECTS
+  // -------------------------------------------------------------------------------------------------
 
   useEffect(() => {
     listFiles();
   }, [])
 
+
+  // -------------------------------------------------------------------------------------------------
+  // FUNCTIONS
+  // -------------------------------------------------------------------------------------------------
+
+  // Gets the asset configs saved locally
   async function listFiles() {
     let fileList = await window.electronAPI.listFilesInFolder();
     console.log('File List: ', fileList);
     setAvailableFiles(fileList);
   }
   
+  // Open the aset-config folder so users can manage them
   async function openFolder() {
     await window.electronAPI.showItemInFolder('asset-configs')
   }
 
+  // Refresh the list of files
   async function handleRefresh() {
     listFiles();
   }
 
 
+  // Loads asset-config, passed data to config-builder component
   async function handleFileSelect(file) {
     console.log('handleFileSelect: ', file);
 
     if (file.validJson) {
       let json = await window.electronAPI.loadFile(file.fileName);
       console.log('json: ', json);
+      setSelectedAssetConfig(json);
     }
     else {
       alert('File is not valid Json. Fix it in a text editor and try again.  Click [Open Folder] to navigate to the directory.');
@@ -40,12 +60,12 @@ function MainPage() {
   }
 
 
-  // on start up, check if any asset-configs exist in asset-configs directy, and display them.  
-  // when selected, load the config builder page.
 
   return (
     <>
       {selectedAssetConfig === null ? 
+
+      // LOADING SCREEN
       <div>
         <h1>Load/New Screen</h1>      
         <span><button onClick={handleRefresh}>Refresh</button></span>  
@@ -72,7 +92,11 @@ function MainPage() {
         </table>
       </div>
         : 
-      <ConfigBuilder/>
+        <>
+          {/* WHEN JSON IS LOADED, DISPLAY CONFIG BUILDER */}
+          <ConfigBuilder assetConfigJSON={selectedAssetConfig} />
+          <button onClick={() => {setSelectedAssetConfig(null)}}>Back</button>
+        </>
       }
     </>
 );

--- a/src/webapps/configBuilder/mainPage.jsx
+++ b/src/webapps/configBuilder/mainPage.jsx
@@ -1,11 +1,80 @@
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import ConfigBuilder from './ConfigBuilder.jsx';
+
+import './index.css';
 
 //add all other config pages to this file
 function MainPage() {
+  const [selectedAssetConfig, setSelectedAssetConfig] = useState(null);
+  const [availableFiles, setAvailableFiles] = useState([]);
+
+  useEffect(() => {
+    listFiles();
+  }, [])
+
+  async function listFiles() {
+    let fileList = await window.electronAPI.listFilesInFolder();
+    console.log('File List: ', fileList);
+    setAvailableFiles(fileList);
+  }
+  
+  async function openFolder() {
+    await window.electronAPI.showItemInFolder('asset-configs')
+  }
+
+  async function handleRefresh() {
+    listFiles();
+  }
+
+
+  async function handleFileSelect(file) {
+    console.log('handleFileSelect: ', file);
+
+    if (file.validJson) {
+      let json = await window.electronAPI.loadFile(file.fileName);
+      console.log('json: ', json);
+    }
+    else {
+      alert('File is not valid Json. Fix it in a text editor and try again.  Click [Open Folder] to navigate to the directory.');
+    }
+  }
+
+
+  // on start up, check if any asset-configs exist in asset-configs directy, and display them.  
+  // when selected, load the config builder page.
 
   return (
-    <ConfigBuilder/>
+    <>
+      {selectedAssetConfig === null ? 
+      <div>
+        <h1>Load/New Screen</h1>      
+        <span><button onClick={handleRefresh}>Refresh</button></span>  
+        <span><button onClick={openFolder}>Open Folder</button></span>  
+        <table id='assetConfigLoader' style={{width: '100%', backgroundColor: 'white', border: '1px solid #ccc'}}>
+          <thead>
+            <tr>
+              <th>File Name</th>
+              <th>Size</th>
+              <th>JSON</th>
+              <th>Last Modified</th>
+            </tr>
+          </thead>
+          <tbody>
+          {availableFiles.map((item, index)=> (
+            <tr key={`file-${index}`} onClick={() => handleFileSelect(item)} className={(!item.validJson) ? 'invalid' : 'hoverable'}>
+              <td>{item.fileName}</td>
+              <td>{item.fileSize}</td>
+              <td>{(item.validJson) ? 'VALID' : 'NOT VALID'}</td>
+              <td>{item.lastModified}</td>
+            </tr>
+          ))}   
+          </tbody>       
+        </table>
+      </div>
+        : 
+      <ConfigBuilder/>
+      }
+    </>
 );
 }
 

--- a/src/webapps/configBuilder/preload.js
+++ b/src/webapps/configBuilder/preload.js
@@ -4,11 +4,14 @@
 const { contextBridge, ipcRenderer } = require('electron/renderer')
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  // loads json in folder
+  // loads and returns all json files in folder
   getFolder: async (folder) => ipcRenderer.invoke('get-Folder', folder),
+  // loads and returns a single json file in folder
+  loadFile: async (file) => ipcRenderer.invoke('load-File', file),
+  // gets list of files in folder
+  listFilesInFolder: async () => ipcRenderer.invoke('listFilesInFolder'),
   // opens file explorer
-  showItemInFolder(fullPath) {
-    console.log('showIteminFolder: ', fullPath);
-    return ipcRenderer.invoke('showItemInFolder', fullPath);
+  showItemInFolder(name) {    
+    return ipcRenderer.invoke('showItemInFolder', name);
   }
 })

--- a/src/webapps/configBuilder/preload.js
+++ b/src/webapps/configBuilder/preload.js
@@ -4,5 +4,11 @@
 const { contextBridge, ipcRenderer } = require('electron/renderer')
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  getFolder: async (folder) => ipcRenderer.invoke('get-Folder', folder)
+  // loads json in folder
+  getFolder: async (folder) => ipcRenderer.invoke('get-Folder', folder),
+  // opens file explorer
+  showItemInFolder(fullPath) {
+    console.log('showIteminFolder: ', fullPath);
+    return ipcRenderer.invoke('showItemInFolder', fullPath);
+  }
 })

--- a/src/webapps/configBuilder/src/ConfigBuilderPage.jsx
+++ b/src/webapps/configBuilder/src/ConfigBuilderPage.jsx
@@ -27,19 +27,19 @@ import ConfigBuilderForm from "./ConfigBuilderForm.jsx";
 import ConfigViewButtonGroup from "./misc/ConfigViewButtonGroup.jsx";
 import ConfigBuilderCreateNewModal from "./misc/ConfigBuilderCreateNewModal.jsx";
 import { copyToClipBoard, copyTextFromInput } from './util/configBuilderPageFunctions';
-import {loadTranslations, sortArray} from "./translation/TranslationUtils";
+import { loadTranslations, sortArray } from "./translation/TranslationUtils";
 
-export default function ConfigBuilderPage() {
+export default function ConfigBuilderPage({assetConfigJSON, schemaJSON}) {
 
     // STATE
     const [showSchema, setShowSchema] = useState(false);
     const [showBuilderForm, setShowBuilderForm] = useState(false);
-    const [configData, setConfigData] = useState({configFileSample})
+    const [configData, setConfigData] = useState(assetConfigJSON) //useState({configFileSample})
     const [modules, setModules] = useState([])
     const [systems, setSystems] = useState([])
     const [schemaData, setSchemaData] = useState({configFormSchema})
-    const [systemSchemas, setSystemSchemas] = useState(Object.keys(configFormSchema.systems));
-    const [moduleSchemas, setModuleSchemas] = useState(Object.keys(configFormSchema.modules));
+    const [systemSchemas, setSystemSchemas] = useState(Object.keys(schemaJSON.systems)); //useState(Object.keys(configFormSchema.systems));
+    const [moduleSchemas, setModuleSchemas] = useState(Object.keys(schemaJSON.modules)); //useState(Object.keys(configFormSchema.modules));
     const [schemaChanged, setSchemaChanged] = useState(0);
     const [fileName, setFileName] = useState("my-asset-config.json");
 
@@ -61,10 +61,12 @@ export default function ConfigBuilderPage() {
     const MODULE = 0;
     const SYSTEM = 1;
 
-    
-    /**
-     * Summary:  Called when schema changes
-     */
+
+    // -------------------------------------------------------------------------------------------------
+    // USE EFFECTS
+    // -------------------------------------------------------------------------------------------------
+        
+    // Summary:  Called when schema changes
     useEffect(()=> {
         if (schemaChanged > 0) {
             const moduleSchemas = Object.keys(schemaData.modules);
@@ -83,6 +85,8 @@ export default function ConfigBuilderPage() {
      * Called first time this component is loaded
      */
     useEffect(()=>{
+        console.log('configData: ', configData);
+
         const configSchemaSample = schemaData?.configFormSchema ?? null;
         if (configSchemaSample) {
             setSchemaData(schemaData.configFormSchema);
@@ -108,6 +112,11 @@ export default function ConfigBuilderPage() {
 
         loadConfigFile(configData);
     }, [configData])
+
+    
+    // -------------------------------------------------------------------------------------------------
+    // FUNCTIONS
+    // -------------------------------------------------------------------------------------------------
 
 
     /**

--- a/src/webapps/configBuilder/src/ConfigBuilderPage.jsx
+++ b/src/webapps/configBuilder/src/ConfigBuilderPage.jsx
@@ -86,12 +86,15 @@ export default function ConfigBuilderPage() {
         const configSchemaSample = schemaData?.configFormSchema ?? null;
         if (configSchemaSample) {
             setSchemaData(schemaData.configFormSchema);
+            console.log(configSchemaSample);
         }
 
         const configFileSample = configData?.configFileSample ?? null;
         if (configFileSample) {            
             setConfigData(configFileSample);
             loadConfigFile(configFileSample);
+
+            //console.log(configFileSample);
         }
     }, [])
 


### PR DESCRIPTION
Users can create their own schemas now.

The following things are included in this PR:
- Pass data from Loading Screen to config builder component.
- Add a back button to go from the Config Builder Screen to the Loading Screen.
- Read in schemas from schemas directory instead of being hardcoded.
- Move all Module and System schemas into separate files in schemas directory.